### PR TITLE
Prevent using organization scope plugin data as it is heavy on performance

### DIFF
--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -30,6 +30,7 @@ function getCardShortLinkFromUrl(cardUrl) {
  *         @var {string} id
  *         @var {string} name
  *         @var {string} url
+ *         @var {string} shortLink
  * }
  */
 async function getCardByIdOrShortLink(t, cardIdOrShortLink) {
@@ -41,9 +42,10 @@ async function getCardByIdOrShortLink(t, cardIdOrShortLink) {
 		});
 		
 		return {
-			id:   response.id,
-			name: response.name,
-			url:  response.url,
+			id:        response.id,
+			name:      response.name,
+			url:       response.url,
+			shortLink: response.shortLink,
 		};
 	}
 	catch (error) {
@@ -608,7 +610,6 @@ function showDebug(t) {
 				items.push({text: 'parent.attachmentId: ' + parent.attachmentId});
 				items.push({text: 'parent.shortLink: ' + parent.shortLink});
 				items.push({text: 'parent.name: ' + parent.name});
-				items.push({text: 'parent.badges: ' + JSON.stringify(parent.badges)});
 			}
 			else {
 				items.push({text: 'parent: -'});
@@ -617,9 +618,11 @@ function showDebug(t) {
 			const children = await t.get('card', 'shared', 'children');
 			if (children !== undefined) {
 				items.push({text: 'children.checklistId: ' + children.checklistId});
-				items.push({text: 'children.shortLinks: ' + children.shortLinks.join(',')});
+				items.push({text: 'children.shortLinks: ' + JSON.stringify(children.shortLinks)});
 				items.push({text: 'children.counts: ' + JSON.stringify(children.counts)});
-				items.push({text: 'children.badges: ' + JSON.stringify(children.badges)});
+			}
+			else {
+				items.push({text: 'children: -'});
 			}
 			
 			return items;

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -488,12 +488,12 @@ function createCheckItem(t, childCard, checklistId) {
 }
 
 function showBadgeOnParent(t, badgeType) {
-	return t.get('card', 'shared', 'children').then(async function(children) {
-		if (children === undefined) {
-			shouldSyncChildren(t).then(function(childrenData) {
-				if (childrenData !== false) {
-					for (let childShortLink of childrenData.shortLinks) {
-						storeChild(t, {shortLink: childShortLink}, childrenData.checklist);
+	return t.get('card', 'shared', 'children').then(async function(childrenData) {
+		if (childrenData === undefined) {
+			shouldSyncChildren(t).then(function(newData) {
+				if (newData !== false) {
+					for (let childShortLink of newData.shortLinks) {
+						storeChild(t, {shortLink: childShortLink}, newData.checklist);
 					}
 				}
 			});
@@ -501,20 +501,20 @@ function showBadgeOnParent(t, badgeType) {
 			return {};
 		}
 		
-		const color = (children.counts.done > 0 && children.counts.done === children.counts.total) ? 'green' : 'light-gray';
+		const color = (childrenData.counts.done > 0 && childrenData.counts.done === childrenData.counts.total) ? 'green' : 'light-gray';
 		
 		switch (badgeType) {
 			case 'card-badges':
 				return {
 					icon:  ICON_DOWN,
-					text:  children.counts.done + '/' + children.counts.total + ' tasks',
+					text:  childrenData.counts.done + '/' + childrenData.counts.total + ' tasks',
 					color: color,
 				};
 			
 			case 'card-detail-badges':
 				return {
 					title: 'Tasks',
-					text:  children.counts.done + '/' + children.counts.total,
+					text:  childrenData.counts.done + '/' + childrenData.counts.total,
 					color: color,
 				};
 		}
@@ -522,11 +522,11 @@ function showBadgeOnParent(t, badgeType) {
 }
 
 function showBadgeOnChild(t, badgeType, attachments) {
-	return t.get('card', 'shared', 'parent').then(async function(parent) {
-		if (parent === undefined) {
-			shouldSyncParent(t, attachments).then(function(parentData) {
-				if (parentData !== false) {
-					storeParent(t, parentData.parentCard, parentData.attachment);
+	return t.get('card', 'shared', 'parent').then(async function(parentData) {
+		if (parentData === undefined) {
+			shouldSyncParent(t, attachments).then(function(syncData) {
+				if (syncData !== false) {
+					storeParent(t, syncData.parentCard, syncData.attachment);
 				}
 			});
 			
@@ -537,16 +537,16 @@ function showBadgeOnChild(t, badgeType, attachments) {
 			case 'card-badges':
 				return {
 					icon:  ICON_UP,
-					text:  'part of ' + parent.name,
+					text:  'part of ' + parentData.name,
 					color: 'light-gray',
 				};
 			
 			case 'card-detail-badges':
 				return {
 					title: 'Part of EPIC',
-					text:  parent.name,
+					text:  parentData.name,
 					callback: function(t, options) {
-						t.showCard(parent.shortLink);
+						t.showCard(parentData.shortLink);
 					},
 				};
 		}

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -393,6 +393,12 @@ async function searchCards(t, options, parentOrChild, callback) {
 async function addParent(t, parentCard) {
 	await t.set('card', 'shared', 'updating', true);
 	
+	await t.get('card', 'shared', 'parent').then(function(parentData) {
+		if (parentData !== undefined) {
+			return removeParent(t, parentData);
+		}
+	});
+	
 	// add parent to child
 	const childCardId = t.getContext().card;
 	const attachment  = await createAttachment(t, parentCard, childCardId);
@@ -568,6 +574,7 @@ function clearStoredChildren(t) {
  * 
  * @param {object} t without context
  * @param {object} parentCard {
+ *        @var {string} name
  *        @var {string} url
  * }
  * @param {string} childCardIdOrShortLink
@@ -575,7 +582,7 @@ function clearStoredChildren(t) {
  */
 function createAttachment(t, parentCard, childCardIdOrShortLink) {
 	const postData = {
-		name: 'EPIC',
+		name: 'EPIC: ' + parentCard.name,
 		url:  parentCard.url,
 	};
 	

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -280,20 +280,11 @@ async function collectChildrenDataToSync(t, checkItems, parentShortLink, current
  */
 async function searchCards(t, options, parentOrChild, callback) {
 	const searchTerm = options.search;
+	const pluginData = await t.get('card', 'shared');
 	
-	// collect current parent
-	let parentCardShortLink = await t.get('card', 'shared', 'parent').then(function(parent) {
-		if (parent !== undefined) {
-			return parent.shortLink;
-		}
-	});
-	
-	// get current children
-	const childCardShortLinks = await t.get('card', 'shared', 'children').then(function(children) {
-		if (children !== undefined) {
-			return children.shortLinks;
-		}
-	});
+	// collect current parent & children
+	const parentCardShortLink = (pluginData.parent   !== undefined ? pluginData.parent.shortLink    : '');
+	const childCardShortLinks = (pluginData.children !== undefined ? pluginData.children.shortLinks : []);
 	
 	// offer to add by card link
 	if (searchTerm !== '' && searchTerm.indexOf('https://trello.com/c/') === 0) {
@@ -301,10 +292,10 @@ async function searchCards(t, options, parentOrChild, callback) {
 			const searchShortLink = getCardShortLinkFromUrl(searchTerm);
 			
 			// skip already added cards
-			if (parentCardShortLink !== undefined && parentCardShortLink === searchShortLink) {
+			if (parentCardShortLink === searchShortLink) {
 				return [];
 			}
-			if (childCardShortLinks !== undefined && childCardShortLinks.includes(searchShortLink)) {
+			if (childCardShortLinks.includes(searchShortLink)) {
 				return [];
 			}
 			
@@ -340,10 +331,10 @@ async function searchCards(t, options, parentOrChild, callback) {
 				if (t.getContext().card === card.id) {
 					return false;
 				}
-				if (parentCardShortLink !== undefined && parentCardShortLink === card.shortLink) {
+				if (parentCardShortLink === card.shortLink) {
 					return false;
 				}
-				if (childCardShortLinks !== undefined && childCardShortLinks.includes(card.shortLink)) {
+				if (childCardShortLinks.includes(card.shortLink)) {
 					return false;
 				}
 				

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -468,16 +468,14 @@ function storeParent(t, parentCard, attachment, contextCardId='card') {
 }
 
 function storeChild(t, checklistId, childCard, checkItem, contextCardId='card') {
-	t.get(contextCardId, 'shared', 'children').then(async function(childrenData) {
-		if (childrenData === undefined) {
-			childrenData = {
-				checklistId:  checklistId,
-				shortLinks:   [],
-				checkItemIds: {},
-				counts:       {total: 0, done:  0},
-			};
-		}
-		
+	const defaultChildrenData = {
+		checklistId:  checklistId,
+		shortLinks:   [],
+		checkItemIds: {},
+		counts:       {total: 0, done:  0},
+	};
+	
+	t.get(contextCardId, 'shared', 'children', defaultChildrenData).then(async function(childrenData) {
 		childrenData.shortLinks.push(childCard.shortLink);
 		childrenData.checkItemIds[childCard.shortLink] = checkItem.id;
 		childrenData.counts.total += 1;

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -221,16 +221,18 @@ async function searchCards(t, options, parentOrChild, callback) {
 	const searchTerm = options.search;
 	
 	// collect current parent
-	let parentCardShortLink = undefined;
-	// @todo re-enable filtering out existing relations
-	//#await t.get('card', 'shared', 'parentAttachmentId').then(async function(parentAttachmentId) {
-	//#	if (parentAttachmentId !== undefined) {
-	//#		parentCardShortLink = await getParentShortLinkByAttachmentId(t, parentAttachmentId);
-	//#	}
-	//#});
+	let parentCardShortLink = await t.get('card', 'shared', 'parent').then(function(parent) {
+		if (parent !== undefined) {
+			return parent.shortLink;
+		}
+	});
 	
 	// get current children
-	const childCardShortLinks = []; //# await t.get('card', 'shared', 'childrenShortLinks');
+	const childCardShortLinks = await t.get('card', 'shared', 'children').then(function(children) {
+		if (children !== undefined) {
+			return children.shortLinks;
+		}
+	});
 	
 	// offer to add by card link
 	if (searchTerm !== '' && searchTerm.indexOf('https://trello.com/c/') === 0) {

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -423,6 +423,8 @@ async function addParent(t, parentCard) {
 }
 
 async function addChild(t, childCard) {
+	await t.set('card', 'shared', 'updating', true);
+	
 	const checklistId = await t.get('card', 'shared', 'children').then(async function(childrenData) {
 		if (childrenData !== undefined) {
 			return childrenData.checklistId;
@@ -439,6 +441,10 @@ async function addChild(t, childCard) {
 	
 	const parentCard = await t.card('url');
 	await createAttachment(t, parentCard, childCard.id);
+	
+	setTimeout(function() {
+		t.remove('card', 'shared', 'updating');
+	}, 100);
 }
 
 function storeParent(t, parentCard, attachment) {
@@ -564,11 +570,14 @@ function createCheckItem(t, childCard, checklistId) {
 function showBadgeOnParent(t, badgeType) {
 	return t.get('card', 'shared', 'children').then(async function(childrenData) {
 		if (badgeType === 'card-badges') {
-			shouldSyncChildren(t, childrenData).then(function(newData) {
-				if (newData !== false) {
-					storeChildren(t, newData);
-				}
-			});
+			const updating = await t.get('card', 'shared', 'updating');
+			if (updating === undefined) {
+				shouldSyncChildren(t, childrenData).then(function(newData) {
+					if (newData !== false) {
+						storeChildren(t, newData);
+					}
+				});
+			}
 		}
 		
 		if (childrenData === undefined) {

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -615,7 +615,8 @@ function showBadgeOnParent(t, badgeType) {
 				getSyncChildrenData(t, childrenData).then(function(newData) {
 					storeChildren(t, newData);
 				})
-				.catch(function() {
+				.catch(function(error) {
+					console.warn('Error processing queue to sync children', error);
 					t.alert({
 						message: 'Something went wrong adding the task, try creating the relationship again.',
 					});
@@ -659,7 +660,8 @@ function showBadgeOnChild(t, badgeType, attachments) {
 			getSyncParentData(t, attachments).then(function(syncData) {
 				storeParent(t, syncData.parentCard, syncData.attachment);
 			})
-			.catch(function() {
+			.catch(function(error) {
+				console.warn('Error processing queue to sync parent', error);
 				t.alert({
 					message: 'Something went wrong adding the EPIC, try creating the relationship again.',
 				});

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -397,6 +397,7 @@ async function searchCards(t, options, parentOrChild, callback) {
 async function addParent(t, parentCard) {
 	await t.set('card', 'shared', 'updating', true);
 	
+	// check existing parent
 	await t.get('card', 'shared', 'parent').then(function(parentData) {
 		if (parentData !== undefined) {
 			return removeParent(t, parentData);
@@ -439,6 +440,15 @@ async function addParent(t, parentCard) {
 
 async function addChild(t, childCard) {
 	await t.set('card', 'shared', 'updating', true);
+	
+	// check existing parent of child
+	const parentOfChild = await getPluginData(t, childCard.id, 'parent');
+	if (parentOfChild !== undefined) {
+		t.alert({
+			message: 'That task is already part of another EPIC. Change the EPIC on that card to switch.',
+		});
+		return;
+	}
 	
 	// add child to parent
 	const checklistId = await t.get('card', 'shared', 'children').then(async function(childrenData) {

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -58,6 +58,23 @@ async function getCardByIdOrShortLink(t, cardIdOrShortLink) {
 
 async function getPluginData(t, cardIdOrShortLink, parentOrChildren) {
 	try {
+		const pluginDataWithinContext = await t.get(cardIdOrShortLink, 'shared', parentOrChildren);
+		if (pluginDataWithinContext !== undefined) {
+			return pluginDataWithinContext;
+		}
+		
+		// fall-through to get plugin data via API
+	}
+	catch (error) {
+		// supress expected error for cards on other boards
+		if (error.message === undefined || error.message !== 'Card not found or not on current board (Command: data)') {
+			console.warn('Error while fetching card plugin data', error);
+		}
+		
+		// fall-through to get plugin data via API
+	}
+	
+	try {
 		const response = await window.Trello.get('cards/' + cardIdOrShortLink + '?fields=&pluginData=true');
 		if (response.pluginData.length === 0) {
 			return;

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -645,7 +645,7 @@ async function removeParent(t, parentData) {
 }
 
 /**
- * add all(!) children relations from current (parent) card
+ * remove all(!) children relations from current (parent) card
  * 
  * @param  {object} t            context
  * @param  {object} childrenData {

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -419,7 +419,7 @@ async function addParent(t, parentCard) {
 	const childCard = await t.card('url', 'shortLink');
 	const checkItem = await createCheckItem(t, childCard, checklistId);
 	
-	if (parentCard.idBoard !== undefined) {
+	if (parentCard.idBoard !== undefined && parentCard.idBoard !== t.getContext().board) {
 		// use organization-level plugindata to store parent data for cross-board relations
 		queueSyncingChildren(t, parentCard.id);
 	}
@@ -456,7 +456,7 @@ async function addChild(t, childCard) {
 	const parentCard = await t.card('name', 'url', 'shortLink');
 	const attachment = await createAttachment(t, parentCard, childCard.id);
 	
-	if (childCard.idBoard !== undefined) {
+	if (childCard.idBoard !== undefined && childCard.idBoard !== t.getContext().board) {
 		// use organization-level plugindata to store parent data for cross-board relations
 		queueSyncingParent(t, childCard.id);
 	}

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -242,12 +242,14 @@ async function collectChildrenDataToSync(t, checklistId, checkItems, parentShort
 		
 		parentOfChild = await getPluginData(t, childShortLink, 'parent');
 		if (parentOfChild === undefined) {
-			// @todo needs different behavior if checklist was certain
 			continue;
 		}
 		if (parentOfChild.shortLink !== parentShortLink) {
-			// @todo needs different behavior if checklist was certain
-			console.warn('child checkitem points to different parent');
+			if (currentData !== undefined) {
+				t.alert({
+					message: 'Task "' + checkItem.name + '" on the tasks checklist relates to a different parent.',
+				});
+			}
 			continue;
 		}
 		

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -725,26 +725,40 @@ function showChildrenForm(t) {
  */
 function showDebug(t) {
 	return t.popup({
-		title: 'Add a task',
+		title: 'Debug EPIC relation',
 		items: async function(t, options) {
 			let items = [];
 			
-			const parent   = await t.get('card', 'shared', 'parent');
-			if (parent !== undefined) {
-				items.push({text: 'parent.attachmentId: ' + parent.attachmentId});
-				items.push({text: 'parent.shortLink: ' + parent.shortLink});
-				items.push({text: 'parent.name: ' + parent.name});
+			const dateLastActivity = await t.card('dateLastActivity').then(function(card) {
+				return card.dateLastActivity;
+			});
+			items.push({text: 'last activity: ' + dateLastActivity});
+			
+			const pluginData = await t.get('card', 'shared');
+			
+			if (pluginData.updating !== undefined) {
+				items.push({text: 'updating: yes'});
+			}
+			else {
+				items.push({text: 'updating: no'});
+			}
+			
+			if (pluginData.parent !== undefined) {
+				items.push({text: 'parent:'});
+				items.push({text: '- attachmentId: ' + pluginData.parent.attachmentId});
+				items.push({text: '- shortLink: ' + pluginData.parent.shortLink});
+				items.push({text: '- name: ' + pluginData.parent.name});
 			}
 			else {
 				items.push({text: 'parent: -'});
 			}
 			
-			const children = await t.get('card', 'shared', 'children');
-			if (children !== undefined) {
-				items.push({text: 'children.checklistId: ' + children.checklistId});
-				items.push({text: 'children.shortLinks: ' + JSON.stringify(children.shortLinks)});
-				items.push({text: 'children.checkItemIds: ' + JSON.stringify(children.checkItemIds)});
-				items.push({text: 'children.counts: ' + JSON.stringify(children.counts)});
+			if (pluginData.children !== undefined) {
+				items.push({text: 'children:'});
+				items.push({text: '- checklistId: ' + pluginData.children.checklistId});
+				items.push({text: '- shortLinks: ' + JSON.stringify(pluginData.children.shortLinks)});
+				items.push({text: '- checkItemIds: ' + JSON.stringify(pluginData.children.checkItemIds)});
+				items.push({text: '- counts: ' + JSON.stringify(pluginData.children.counts)});
 			}
 			else {
 				items.push({text: 'children: -'});


### PR DESCRIPTION
Replace it with:

- add attachment/checkitem via API
- badge on card which detects those changes
- checks the plugindata of the related card
- and then sets plugindata on own card

Preventing organization scope data prevents reloading on each card in the org, at the cost of a bit more processing on the card that changes. Maybe still use organization level when the card is on another board.