### PR TITLE
Fix changing EPIC card title isn't changed on child card's badges

### DIFF
--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -941,6 +941,14 @@ function storeParent(t, parentCard, attachment, contextCardId='card') {
 	});
 }
 
+/**
+ * update the name in the stored parent data
+ * 
+ * @param  {object} t             without context
+ * @param  {object} parentData
+ * @param  {string} parentName
+ * @param  {string} contextCardId optional, defaults to 'card'
+ */
 function updateParentName(t, parentData, parentName, contextCardId='card') {
 	const cardId = (contextCardId !== 'card') ? contextCardId : t.getContext().card;
 	

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -713,13 +713,13 @@ async function removeChild(t, childrenData, shortLink) {
 }
 
 /**
- * process queue of actions delayed because the card was out of context
+ * process changes on the card and the queue of actions delayed because the card was out of context
  * 
  * @param  {object}  t          context
  * @param  {string}  badgeType  front ('card-badges') or back ('card-detail-badges') of the card
  * @param  {Promise} pluginData
  */
-function processQueue(t, badgeType, pluginData) {
+function processChanges(t, badgeType, pluginData) {
 	Promise.all([
 		pluginData,
 		t.card('name', 'dateLastActivity'),
@@ -1479,7 +1479,7 @@ TrelloPowerUp.initialize({
 		return Promise.all([
 			showBadgeOnParent(t, options.context.command, pluginData),
 			showBadgeOnChild(t, options.context.command, pluginData),
-			processQueue(t, options.context.command, pluginData),
+			processChanges(t, options.context.command, pluginData),
 		]);
 	},
 	'card-detail-badges': function(t, options) {
@@ -1488,7 +1488,7 @@ TrelloPowerUp.initialize({
 		return Promise.all([
 			showBadgeOnParent(t, options.context.command, pluginData),
 			showBadgeOnChild(t, options.context.command, pluginData),
-			processQueue(t, options.context.command, pluginData),
+			processChanges(t, options.context.command, pluginData),
 		]);
 	},
 	'authorization-status': function(t) {

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -838,6 +838,11 @@ function processChanges(t, badgeType, pluginData) {
 		if (badgeType === 'card-badges') {
 			// process changing name of parent card
 			if (hasNewActivity && hasChildren) {
+				const isAuthorized = await initializeAuthorization(t);
+				if (isAuthorized === false) {
+					throw new Error('not authorized to sync');
+				}
+				
 				for (let childShortLink of pluginData.children.shortLinks) {
 					let parentOfChild = await getPluginData(t, childShortLink, 'parent');
 					if (parentOfChild === undefined) {
@@ -848,7 +853,6 @@ function processChanges(t, badgeType, pluginData) {
 						continue;
 					}
 					
-					// @todo get auth before this step
 					let childCard = await getCardByIdOrShortLink(t, childShortLink);
 					if (childCard.idBoard !== undefined && childCard.idBoard !== t.getContext().board) {
 						// use organization-level plugindata to store parent data for cross-board relations

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -842,10 +842,10 @@ function processChanges(t, badgeType, pluginData) {
 					let parentOfChild = await getPluginData(t, childShortLink, 'parent');
 					if (parentOfChild === undefined) {
 						console.warn('Skip syncing parent name change to child card ' + childShortLink + ', probably unprocessed cross-board child');
-						return;
+						continue;
 					}
 					if (parentOfChild.name === cardData.name) {
-						return;
+						continue;
 					}
 					
 					// @todo get auth before this step

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -741,6 +741,35 @@ function releaseAsUpdating(t) {
 }
 
 /**
+ * process queue of actions delayed because the card was out of context
+ * 
+ * @param  {object}  t          context
+ * @param  {Promise} pluginData
+ */
+function processQueue(t, pluginData) {
+	t.get('organization', 'shared', 'sync-parent-' + t.getContext().card, false).then(function(shouldSyncParent) {
+		if (shouldSyncParent === false) {
+			return;
+		}
+		
+		processParentQueue(t);
+	});
+	t.get('organization', 'shared', 'sync-children-' + t.getContext().card, false).then(function(shouldSyncChildren) {
+		if (shouldSyncChildren === false) {
+			return;
+		}
+		
+		Promise.all([
+			pluginData,
+			t.card('shortLink'),
+		]).then(function(values) {
+			let [pluginData, cardData] = values;
+			processChildrenQueue(t, pluginData, cardData);
+		});
+	});
+}
+
+/**
  * process changes on the card
  * 
  * @param  {object}  t          context
@@ -782,35 +811,6 @@ function processChanges(t, badgeType, pluginData) {
 		if (badgeType === 'card-detail-badges') {
 			processChildrenCounts(t, pluginData);
 		}
-	});
-}
-
-/**
- * process queue of actions delayed because the card was out of context
- * 
- * @param  {object}  t          context
- * @param  {Promise} pluginData
- */
-function processQueue(t, pluginData) {
-	t.get('organization', 'shared', 'sync-parent-' + t.getContext().card, false).then(function(shouldSyncParent) {
-		if (shouldSyncParent === false) {
-			return;
-		}
-		
-		processParentQueue(t);
-	});
-	t.get('organization', 'shared', 'sync-children-' + t.getContext().card, false).then(function(shouldSyncChildren) {
-		if (shouldSyncChildren === false) {
-			return;
-		}
-		
-		Promise.all([
-			pluginData,
-			t.card('shortLink'),
-		]).then(function(values) {
-			let [pluginData, cardData] = values;
-			processChildrenQueue(t, pluginData, cardData);
-		});
 	});
 }
 

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -833,8 +833,10 @@ function processChanges(t, badgeType, pluginData) {
 		
 		const hasNewActivity = (pluginData.cachedDateLastActivity === undefined || pluginData.cachedDateLastActivity !== cardData.dateLastActivity);
 		const hasChildren    = (pluginData.children !== undefined);
+		const isUpdating     = (pluginData.updating !== undefined);
 		
 		if (badgeType === 'card-badges') {
+			// process changing name of parent card
 			if (hasNewActivity && hasChildren) {
 				for (let childShortLink of pluginData.children.shortLinks) {
 					let parentOfChild = await getPluginData(t, childShortLink, 'parent');
@@ -861,7 +863,8 @@ function processChanges(t, badgeType, pluginData) {
 		
 		if (badgeType === 'card-detail-badges') {
 			// process marking child checkitems as complete
-			if (childrenData !== undefined && pluginData.updating === undefined) {
+			if (hasChildren && isUpdating === false) {
+				const childrenData = pluginData.children;
 				getChildrenCountData(t, childrenData).then(function(newCounts) {
 					if (JSON.stringify(newCounts) !== JSON.stringify(childrenData.counts)) {
 						childrenData.counts = newCounts;

--- a/power-up/js/client.js
+++ b/power-up/js/client.js
@@ -777,6 +777,12 @@ function processChanges(t, badgeType, pluginData) {
 		if (badgeType === 'card-badges') {
 			if (hasNewActivity && isCopiedCard) {
 				processCopiedCard(t);
+				
+				// make sure to not further process this copied card
+				return;
+			}
+			if (hasNewActivity && hasChildren) {
+				processParentNameChange(t, pluginData, cardData);
 			}
 		}
 		
@@ -789,7 +795,6 @@ function processChanges(t, badgeType, pluginData) {
 			}
 			if (hasNewActivity && hasChildren) {
 				processChildrenCounts(t, pluginData);
-				processParentNameChange(t, pluginData, cardData)
 			}
 		}
 	});
@@ -1068,6 +1073,7 @@ function clearStoredChildren(t) {
  */
 function clearStoredData(t) {
 	t.remove('card', 'shared', [
+		'cachedDateLastActivity',
 		'children',
 		'copyDetection',
 		'parent',


### PR DESCRIPTION
- [x] check cached lastActivity instead of always on card load
- [x] check if this works when updating a card's title from the front of the card
- [x] docblocks
- [x] test if inner promises can use await, to make the flow more readable, without blocking the processQueue 'badge'
- [x] fix unprocessed cross-board relationships
- [x] process `@todo`s